### PR TITLE
Simplify interface of the Tsort module. This breaks the existing API.

### DIFF
--- a/src/lib/tsort.ml
+++ b/src/lib/tsort.ml
@@ -7,7 +7,6 @@
 
 type 'a sort_result =
   | Sorted of 'a list
-  | ErrorNonexistent of 'a list
   | ErrorCycle of 'a list
 
 (* Finds "isolated" nodes,
@@ -59,6 +58,26 @@ let find_nonexistent_nodes nodes =
     ) [] nodes in
   CCList.uniq ~eq:(=) nonexistent
 
+(*
+   Append missing nodes to the graph, in the order in which they were
+   encountered. This particular order doesn't have to be guaranteed by the
+   API but seems nice to have.
+*)
+let add_missing_nodes graph_l graph =
+  let missing =
+    List.fold_left (fun acc (_, vl) ->
+      List.fold_left (fun acc v ->
+        if not (Hashtbl.mem graph v) then
+          (v, []) :: acc
+        else
+          acc
+      ) acc vl
+    ) [] graph_l
+    |> List.rev
+  in
+  List.iter (fun (v, vl) -> Hashtbl.replace graph v vl) missing;
+  graph_l @ missing
+
 (* The Kahn's algorithm:
     1. Find nodes that have no dependencies ("isolated") and remove them from
        the graph hash.
@@ -84,6 +103,7 @@ let sort nodes =
         (List.append deps isolated_nodes) hash (List.append acc isolated_nodes)
   in
   let nodes_hash = CCHashtbl.of_list nodes in
+  let _nodes = add_missing_nodes nodes nodes_hash in
   let base_nodes = find_isolated_nodes nodes_hash in
   let () = remove_nodes base_nodes nodes_hash in
   let sorted_node_ids = sorting_loop base_nodes nodes_hash [] in
@@ -91,202 +111,178 @@ let sort nodes =
   let remaining_ids = CCHashtbl.keys_list nodes_hash in
   match remaining_ids with
   | [] -> Sorted sorted_node_ids
-  | _  ->
-    let nonexistent_nodes = find_nonexistent_nodes nodes in
-    begin
-      match nonexistent_nodes with
-      | [] -> ErrorCycle remaining_ids
-      | _  -> ErrorNonexistent nonexistent_nodes
-    end
+  | _  -> ErrorCycle remaining_ids
 
 (*
    Deal with cyclic graphs.
 *)
-module Components = struct
-  module Graph = struct
-    type ('a, 'b) t = ('a, 'b list) Hashtbl.t
+module Graph = struct
+  type ('a, 'b) t = ('a, 'b list) Hashtbl.t
 
-    let create l : (_, _) t =
-      let tbl = Hashtbl.create 100 in
-      List.iter (fun (k, v) -> Hashtbl.replace tbl k v) l;
-      tbl
+  let create l : (_, _) t =
+    let tbl = Hashtbl.create 100 in
+    List.iter (fun (k, v) -> Hashtbl.replace tbl k v) l;
+    tbl
 
-    let transpose tbl =
-      let tbl2 = Hashtbl.create 100 in
-      let init v =
-        if not (Hashtbl.mem tbl2 v) then
-          Hashtbl.add tbl2 v []
-      in
-      Hashtbl.iter (fun u vl ->
-        init u;
-        List.iter (fun v ->
-          let ul =
-            try Hashtbl.find tbl2 v
-            with Not_found -> []
-          in
-          Hashtbl.replace tbl2 v (u :: ul)
-        ) vl
-      ) tbl;
-      tbl2
-
-    let _to_list tbl =
-      Hashtbl.fold (fun u vl acc -> (u, vl) :: acc) tbl []
-  end
-
-  let add_missing_nodes graph_l graph =
-    let missing =
-      List.fold_left (fun acc (_, vl) ->
-        List.fold_left (fun acc v ->
-          if not (Hashtbl.mem graph v) then
-            (v, []) :: acc
-          else
-            acc
-        ) acc vl
-      ) [] graph_l
-      |> List.rev
+  let transpose tbl =
+    let tbl2 = Hashtbl.create 100 in
+    let init v =
+      if not (Hashtbl.mem tbl2 v) then
+        Hashtbl.add tbl2 v []
     in
-    List.iter (fun (v, vl) -> Hashtbl.replace graph v vl) missing;
-    graph_l @ missing
-
-  (*
-     Sort the results of 'partition' so as to follow the original node
-     ordering. If not for the user, it's useful for us for testing.
-  *)
-  let sort_partition graph_l clusters =
-    let priority = Hashtbl.create 100 in
-    List.iteri (fun i (v, _) -> Hashtbl.replace priority v i) graph_l;
-    let prio v =
-      try Hashtbl.find priority v
-      with Not_found -> assert false
-    in
-    let list_prio vl =
-      match vl with
-      | [] -> assert false
-      | x :: _ -> prio x
-    in
-    let cmp u v = compare (prio u) (prio v) in
-    let cmp_list ul vl = compare (list_prio ul) (list_prio vl) in
-    List.map (fun l -> List.sort cmp l) clusters
-    |> List.sort cmp_list
-
-  (*
-     Implementation of Kosaraju's algorithm for partitioning a graph into its
-     strongly connected components.
-  *)
-  let partition_full graph_l =
-    let graph = Graph.create graph_l in
-    let graph_l = add_missing_nodes graph_l graph in
-    let tr_graph = Graph.transpose graph in
-    let visits = Hashtbl.create 100 in
-    let is_visited v = Hashtbl.mem visits v in
-    let mark_visited v = Hashtbl.replace visits v () in
-    let get_out_neighbors v =
-      try Hashtbl.find graph v
-      with Not_found -> assert false
-    in
-    let get_in_neighbors v =
-      try Hashtbl.find tr_graph v
-      with Not_found -> assert false
-    in
-    let rec visit acc v =
-      if not (is_visited v) then (
-        mark_visited v;
-        let out_neighbors = get_out_neighbors v in
-        let acc =
-          List.fold_left (fun acc u -> visit acc u) acc out_neighbors in
-        v :: acc
-      )
-      else
-        acc
-    in
-    let l =
-      List.fold_left (fun acc (v, _vl) ->
-        visit acc v
-      ) [] graph_l
-    in
-    let assignments = Hashtbl.create 100 in
-    let is_assigned v = Hashtbl.mem assignments v in
-    let rec assign v root =
-      if not (is_assigned v) then (
-        Hashtbl.replace assignments v root;
-        let in_neighbors = get_in_neighbors v in
-        List.iter (fun u ->
-          assign u root
-        ) in_neighbors
-      )
-    in
-    List.iter (fun v ->
-      assign v v
-    ) l;
-    (* end Kosaraju's algorithm *)
-
-    let clusters = Hashtbl.create 100 in
-    Hashtbl.iter (fun v id ->
-      let members =
-        try Hashtbl.find clusters id
-        with Not_found -> []
-      in
-      Hashtbl.replace clusters id (v :: members)
-    ) assignments;
-    let partition =
-      Hashtbl.fold (fun _id members acc -> members :: acc) clusters []
-    in
-    graph_l, sort_partition graph_l partition
-
-  let partition graph_l =
-    let _completed_graph_l, components = partition_full graph_l in
-    components
-
-  (*
-     Algorithm:
-     1. Identify the strongly-connected components of the input graph.
-     2. Derive a DAG from merging the nodes within each component
-        (condensation).
-     3. Topologically-sort that DAG.
-     4. Re-expand the nodes representing components into the original nodes.
-  *)
-  let sort graph_l =
-    let graph_l, components = partition_full graph_l in
-    let index = Hashtbl.create 100 in
-    let rev_index = Hashtbl.create 100 in
-    List.iteri (fun id comp ->
+    Hashtbl.iter (fun u vl ->
+      init u;
       List.iter (fun v ->
-        Hashtbl.add index v id;
-        Hashtbl.add rev_index id comp
-      ) comp
-    ) components;
-
-    let get_comp_id v =
-      try Hashtbl.find index v
-      with Not_found -> assert false
-    in
-    let get_comp_members id =
-      try Hashtbl.find rev_index id
-      with Not_found -> assert false
-    in
-    let condensation =
-      let tbl = Hashtbl.create 100 in
-      List.iter (fun (u, vl) ->
-        let id = get_comp_id u in
-        let idl0 =
-          try Hashtbl.find tbl id
+        let ul =
+          try Hashtbl.find tbl2 v
           with Not_found -> []
         in
-        let idl = List.map get_comp_id vl @ idl0 in
-        Hashtbl.replace tbl id idl
-      ) graph_l;
-      Hashtbl.fold (fun id idl acc ->
-        (* Remove v->v edges because they are not supported by tsort.
-           Duplicates seem ok. *)
-        let filtered = List.filter ((<>) id) idl in
-        (id, filtered) :: acc
-      ) tbl []
-    in
-    let sorted_components =
-      match sort condensation with
-      | Sorted comp_ids -> List.map get_comp_members comp_ids
-      | ErrorNonexistent _ -> assert false
-      | ErrorCycle _ -> assert false
-    in
-    sorted_components
+        Hashtbl.replace tbl2 v (u :: ul)
+      ) vl
+    ) tbl;
+    tbl2
+
+  let _to_list tbl =
+    Hashtbl.fold (fun u vl acc -> (u, vl) :: acc) tbl []
 end
+
+(*
+   Sort the results of 'partition' so as to follow the original node
+   ordering. If not for the user, it's useful for us for testing.
+*)
+let sort_partition graph_l clusters =
+  let priority = Hashtbl.create 100 in
+  List.iteri (fun i (v, _) -> Hashtbl.replace priority v i) graph_l;
+  let prio v =
+    try Hashtbl.find priority v
+    with Not_found -> assert false
+  in
+  let list_prio vl =
+    match vl with
+    | [] -> assert false
+    | x :: _ -> prio x
+  in
+  let cmp u v = compare (prio u) (prio v) in
+  let cmp_list ul vl = compare (list_prio ul) (list_prio vl) in
+  List.map (fun l -> List.sort cmp l) clusters
+  |> List.sort cmp_list
+
+(*
+   Implementation of Kosaraju's algorithm for partitioning a graph into its
+   strongly connected components.
+*)
+let partition graph_l =
+  let graph = Graph.create graph_l in
+  let graph_l = add_missing_nodes graph_l graph in
+  let tr_graph = Graph.transpose graph in
+  let visits = Hashtbl.create 100 in
+  let is_visited v = Hashtbl.mem visits v in
+  let mark_visited v = Hashtbl.replace visits v () in
+  let get_out_neighbors v =
+    try Hashtbl.find graph v
+    with Not_found -> assert false
+  in
+  let get_in_neighbors v =
+    try Hashtbl.find tr_graph v
+    with Not_found -> assert false
+  in
+  let rec visit acc v =
+    if not (is_visited v) then (
+      mark_visited v;
+      let out_neighbors = get_out_neighbors v in
+      let acc =
+        List.fold_left (fun acc u -> visit acc u) acc out_neighbors in
+      v :: acc
+    )
+    else
+      acc
+  in
+  let l =
+    List.fold_left (fun acc (v, _vl) ->
+      visit acc v
+    ) [] graph_l
+  in
+  let assignments = Hashtbl.create 100 in
+  let is_assigned v = Hashtbl.mem assignments v in
+  let rec assign v root =
+    if not (is_assigned v) then (
+      Hashtbl.replace assignments v root;
+      let in_neighbors = get_in_neighbors v in
+      List.iter (fun u ->
+        assign u root
+      ) in_neighbors
+    )
+  in
+  List.iter (fun v ->
+    assign v v
+  ) l;
+  (* end Kosaraju's algorithm *)
+
+  let clusters = Hashtbl.create 100 in
+  Hashtbl.iter (fun v id ->
+    let members =
+      try Hashtbl.find clusters id
+      with Not_found -> []
+    in
+    Hashtbl.replace clusters id (v :: members)
+  ) assignments;
+  let partition =
+    Hashtbl.fold (fun _id members acc -> members :: acc) clusters []
+  in
+  graph_l, sort_partition graph_l partition
+
+let find_strongly_connected_components graph_l =
+  let _completed_graph_l, components = partition graph_l in
+  components
+
+(*
+   Algorithm:
+   1. Identify the strongly-connected components of the input graph.
+   2. Derive a DAG from merging the nodes within each component
+      (condensation).
+   3. Topologically-sort that DAG.
+   4. Re-expand the nodes representing components into the original nodes.
+*)
+let sort_strongly_connected_components graph_l =
+  let graph_l, components = partition graph_l in
+  let index = Hashtbl.create 100 in
+  let rev_index = Hashtbl.create 100 in
+  List.iteri (fun id comp ->
+    List.iter (fun v ->
+      Hashtbl.add index v id;
+      Hashtbl.add rev_index id comp
+    ) comp
+  ) components;
+
+  let get_comp_id v =
+    try Hashtbl.find index v
+    with Not_found -> assert false
+  in
+  let get_comp_members id =
+    try Hashtbl.find rev_index id
+    with Not_found -> assert false
+  in
+  let condensation =
+    let tbl = Hashtbl.create 100 in
+    List.iter (fun (u, vl) ->
+      let id = get_comp_id u in
+      let idl0 =
+        try Hashtbl.find tbl id
+        with Not_found -> []
+      in
+      let idl = List.map get_comp_id vl @ idl0 in
+      Hashtbl.replace tbl id idl
+    ) graph_l;
+    Hashtbl.fold (fun id idl acc ->
+      (* Remove v->v edges because they are not supported by tsort.
+         Duplicates seem ok. *)
+      let filtered = List.filter ((<>) id) idl in
+      (id, filtered) :: acc
+    ) tbl []
+  in
+  let sorted_components =
+    match sort condensation with
+    | Sorted comp_ids -> List.map get_comp_members comp_ids
+    | ErrorCycle _ -> assert false
+  in
+  sorted_components

--- a/src/lib/tsort.mli
+++ b/src/lib/tsort.mli
@@ -4,7 +4,6 @@
 
 type 'a sort_result =
   | Sorted of 'a list
-  | ErrorNonexistent of 'a list
   | ErrorCycle of 'a list
 
 (** Perform a normal topological sort on a directed acyclic graph (DAG).
@@ -12,31 +11,50 @@ type 'a sort_result =
     The result is in "dependency order", i.e. if there's an edge from
     A to B, then B comes first. For example,
     [sort [1, [2]; 2, []]] returns [[2; 1]].
+
+    If your graph may contain legitimate cycles, consider using
+    [sort_strongly_connected_components] instead.
+
+    Missing nodes such as node 2 in graph [[1, [2]]] are automatically added,
+    resulting in the graph [[1, [2]; 2, []]]. If this is undesirable,
+    consider running [find_nonexistent_nodes] on the input graph.
 *)
 val sort : ('a * 'a list) list -> 'a sort_result
 
-(** Dealing with cyclic graphs.
+(** Perform a topological sort on a directed graph that may have cycles.
+    Uses [find_strongly_connected_components] and [sort].
+
+    Like with [sort], missing nodes are silently added to the graph.
+
+    For example, [find_strongly_connected_components
+    ["A", ["B"]; "B", ["C"]; "C", ["B"; "D"]]] returns
+    [["D"]; ["B"; "C"]; ["A"]].
 *)
-module Components : sig
-  (** Perform a topological sort on a directed graph that may have cycles.
-      Uses [partition] and [Tsort.sort].
-  *)
-  val sort : ('a * 'a list) list -> 'a list list
+val sort_strongly_connected_components : ('a * 'a list) list -> 'a list list
 
-  (**
-     Partition a graph into its strongly-connected components:
-     Two vertices u, v belong to the same component iff there's a path from
-     u to v and there's a path from v to u.
+(** Report nodes mentioned in a list of out-neighbors but not explicitly
+    listed otherwise. This is useful for detecting user-entry errors,
+    since the other functions of the module silently add those nodes to
+    the graph.
 
-     See https://en.wikipedia.org/wiki/Strongly_connected_component
+    For example, [find_nonexistent_nodes ["test", ["biuld"]; "build", []]]
+    returns [["biuld"]].
+*)
+val find_nonexistent_nodes : ('a * 'a list) list -> 'a list
 
-     The current implementation uses the Kosaraju-Sharir algorithm,
-     which is described at
-     https://en.wikipedia.org/wiki/Kosaraju%27s_algorithm
+(**
+   Partition a graph into its strongly-connected components:
+   Two vertices u, v belong to the same component iff there's a path from
+   u to v and there's a path from v to u.
 
-     The theoretical complexity of the Kosaraju-Sharir algorithm is
-     O(n) = O(|V|+|E|) but due to the use of resizable hash tables and a final
-     sorting pass, the complexity of this implementation is O(n log n).
-  *)
-  val partition : ('a * 'a list) list -> 'a list list
-end
+   See https://en.wikipedia.org/wiki/Strongly_connected_component
+
+   The current implementation uses the Kosaraju-Sharir algorithm,
+   which is described at
+   https://en.wikipedia.org/wiki/Kosaraju%27s_algorithm
+
+   The theoretical complexity of the Kosaraju-Sharir algorithm is
+   O(n) = O(|V|+|E|) but due to the use of resizable hash tables and a final
+   sorting pass, the complexity of this implementation is O(n log n).
+*)
+val find_strongly_connected_components : ('a * 'a list) list -> 'a list list

--- a/src/test/test_tsort.ml
+++ b/src/test/test_tsort.ml
@@ -21,10 +21,17 @@ let fmt_tsort_result res =
   match res with
   | Tsort.Sorted l ->
       sprintf "Sorted %s" (fmt_list string_of_int l)
-  | Tsort.ErrorNonexistent l ->
-      sprintf "ErrorNonexistent %s" (fmt_list string_of_int l)
   | Tsort.ErrorCycle l ->
       sprintf "ErrorCycle %s" (fmt_list string_of_int l)
+
+let test_find_nonexistent_nodes () =
+  assert (
+    (Tsort.find_nonexistent_nodes
+       [1, []; 2, [3]; 4, [5; 7]; 6, [2]]
+     |> List.sort compare
+    )
+    = [3; 5; 7]
+  )
 
 let test_tsort () =
   let sort graph =
@@ -50,10 +57,10 @@ let test_tsort () =
     Sorted [7; 6; 4; 5; 3; 2; 1]
   )
 
-let test_component_partition () =
+let test_find_sc_components () =
   let p graph =
     printf "input: %s\n%!" (fmt_graph graph);
-    let partition = Tsort.Components.partition graph in
+    let partition = Tsort.find_strongly_connected_components graph in
     printf "output: %s\n%!" (fmt_partition partition);
     partition
   in
@@ -86,10 +93,10 @@ let test_component_partition () =
     = [[1]; [2; 3; 4]; [5]]
   )
 
-let test_component_sort () =
+let test_sort_sc_components () =
   let sort graph =
     printf "input: %s\n%!" (fmt_graph graph);
-    let components = Tsort.Components.sort graph in
+    let components = Tsort.sort_strongly_connected_components graph in
     printf "output: %s\n%!" (fmt_partition components);
     components
   in
@@ -108,11 +115,10 @@ let test_component_sort () =
 let main () =
   Alcotest.run "Tsort" [
     "Tsort", [
+      "find nonexistent nodes", `Quick, test_find_nonexistent_nodes;
       "sort", `Quick, test_tsort;
-    ];
-    "Tsort.Components", [
-      "partition", `Quick, test_component_partition;
-      "sort", `Quick, test_component_sort;
+      "find s.c. components", `Quick, test_find_sc_components;
+      "sort s.c. components", `Quick, test_sort_sc_components;
     ];
   ]
 


### PR DESCRIPTION
This implements the changes discussed in PR https://github.com/dmbaturin/ocaml-tsort/pull/1
