### PR TITLE
Fix compatibility issues + add CI badge!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-ocaml-tsort
+ocaml-tsort [![CircleCI badge](https://circleci.com/gh/dmbaturin/ocaml-tsort.svg?style=svg)](https://app.circleci.com/pipelines/github/dmbaturin/ocaml-tsort)
 ===========
 
 This module provides topological sort based on Kahn's algorithm. It's not very fast, but it's easy to use

--- a/src/lib/compat.ml
+++ b/src/lib/compat.ml
@@ -1,0 +1,24 @@
+(*
+   Basic functions not available in older versions of OCaml's standard
+   library.
+*)
+
+module Hashtbl = struct
+  let find_opt tbl key =
+    try Some (Hashtbl.find tbl key)
+    with Not_found -> None
+end
+
+module List = struct
+  let filter_map f l =
+    List.fold_left (fun acc x ->
+      match f x with
+      | None -> acc
+      | Some y -> y :: acc
+    ) [] l
+    |> List.rev
+
+  let find_opt f l =
+    try Some (List.find f l)
+    with Not_found -> None
+end

--- a/src/lib/tsort.ml
+++ b/src/lib/tsort.ml
@@ -68,7 +68,7 @@ let deduplicate l =
 let find_nonexistent_nodes nodes =
   let graph = Hashtbl.create (List.length nodes) in
   List.iter (fun (u, vl) -> Hashtbl.add graph u vl) nodes;
-  List.filter_map (fun (u, vl) ->
+  Compat.List.filter_map (fun (u, vl) ->
     let missing =
       List.filter (fun v -> not (Hashtbl.mem graph v)) vl
       |> deduplicate

--- a/tsort.opam
+++ b/tsort.opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "containers"
+  "containers" {>= "2.5"}
   "dune" {>= "1.9"}
 ]
 synopsis: "Easy to use and user-friendly topological sort"


### PR DESCRIPTION
Everything's in order now. Works with ocaml 4.03 and 4.10.

It's not as fast as I thought it would be. Maybe it could be improved by installing all the packages in one `opam install` instead of two in the `setup` file but it's more annoying to maintain and it doesn't seem critical.
